### PR TITLE
added autoPrefixerOpts prop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 coverage
 node_modules
 lib
+npm-debug.log

--- a/DEV_ONLY/App.js
+++ b/DEV_ONLY/App.js
@@ -61,14 +61,14 @@ RegularDiv.propTypes = {
   color: PropTypes.string
 };
 
-const CustomAutoPrefixerDiv = ({color}) => {
+const CustomAutoprefixerDiv = ({color}) => {
   return (
     <div>
       <div className={foo}>
         I have no flexbox prefixes
       </div>
 
-      <Style autoPrefixerOpts={{
+      <Style autoprefixerOptions={{
         flexbox: false
       }}>{`
         .${foo} {
@@ -81,7 +81,7 @@ const CustomAutoPrefixerDiv = ({color}) => {
   );
 };
 
-CustomAutoPrefixerDiv.propTypes = {
+CustomAutoprefixerDiv.propTypes = {
   color: PropTypes.string
 };
 
@@ -156,7 +156,7 @@ class App extends Component {
 
         <br/>
 
-        <CustomAutoPrefixerDiv color={color}/>
+        <CustomAutoprefixerDiv color={color}/>
 
         <br/>
 

--- a/DEV_ONLY/App.js
+++ b/DEV_ONLY/App.js
@@ -61,6 +61,30 @@ RegularDiv.propTypes = {
   color: PropTypes.string
 };
 
+const CustomAutoPrefixerDiv = ({color}) => {
+  return (
+    <div>
+      <div className={foo}>
+        I have no flexbox prefixes
+      </div>
+
+      <Style autoPrefixerOpts={{
+        flexbox: false
+      }}>{`
+        .${foo} {
+          color: ${color};
+          display: inline-flex;
+          transition: color 250ms ease-in-out;
+        }
+      `}</Style>
+    </div>
+  );
+};
+
+CustomAutoPrefixerDiv.propTypes = {
+  color: PropTypes.string
+};
+
 const ToggledDiv = ({color, id}) => {
   return (
     <div>
@@ -129,6 +153,10 @@ class App extends Component {
         <br/>
 
         <RegularDiv color={color}/>
+
+        <br/>
+
+        <CustomAutoPrefixerDiv color={color}/>
 
         <br/>
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Notice you can easily mix both scoped and global styles, and for mental mapping 
 
 #### Props
 
-Naturally you can pass all standard attributes (`id`, `name`, etc.) and they will be passed to the `<style>` tag, but there are a couple of additional props that are specific to the component.
+Naturally you can pass all standard attributes (`id`, `name`, etc.) and they will be passed to the `<style>` tag, but there are a few  additional props that are specific to the component.
 
 **doNotPrefix** *boolean, defaults to false*
 
@@ -156,6 +156,10 @@ This would result in:
 <style>.test{display:block}</style>
 ```
 
+**autoPrefixerOpts** *object, defaults to `{ remove: false }`*
+
+This prop can be set to any plain object containing options for the [autoPrefixer](https://www.npmjs.com/package/autoprefixer#options). The autoPrefixer instance generation is memoized, so using the same `autoPrefixerOpts` prop across multiple `Style` components should be performant.
+
 ### Global Options
 
 All of the props available are also available as global options for all instances that can be set with the `setGlobalOptions` method:
@@ -166,7 +170,8 @@ import Style from 'react-style-tag';
 Style.setGlobalOptions({
   doNotPrefix: true,
   hasSourceMap: true,
-  isMinified: true
+  isMinified: true,
+  autoPrefixerOpts: { remove: true }
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,27 @@ This would result in:
 
 **autoprefixerOptions** *object, defaults to `{ remove: false }`*
 
-This prop can be set to any plain object containing options for the [autoprefixer](https://www.npmjs.com/package/autoprefixer#options). The autoprefixer instance generation is memoized, so using the same `autoprefixerOptions` prop across multiple `Style` components should be performant.
+This prop can be set to any plain object containing options for the [autoprefixer](https://www.npmjs.com/package/autoprefixer#options).
+
+The autoprefixer instance generation is memoized, so using the same `autoprefixerOptions` prop across multiple `Style` components should be performant as long as the same object instance is used. So, in the case of multiple `Style` tags with the same autoprefixerOptions:
+
+```
+<Style autoprefixerOptions={{ remove: true }}>{cssText}</Style>
+
+// later in the code - this will cause another autoprefixer instance to be created
+<Style autoprefixerOptions={{ remove: true }}>{cssText}</Style>
+```
+
+A better approach would be to define the options once and reuse the options object.
+
+```
+const AUTOPREFIXER_OPTIONS = {remove: true};
+
+<Style autoprefixerOptions={AUTOPREFIXER_OPTIONS}>{cssText}</Style>
+
+// later in the code - this will reuse the same autoprefixer instance
+<Style autoprefixerOptions={AUTOPREFIXER_OPTIONS}>{cssText}</Style>
+```
 
 ### Global Options
 

--- a/README.md
+++ b/README.md
@@ -156,9 +156,9 @@ This would result in:
 <style>.test{display:block}</style>
 ```
 
-**autoPrefixerOpts** *object, defaults to `{ remove: false }`*
+**autoprefixerOptions** *object, defaults to `{ remove: false }`*
 
-This prop can be set to any plain object containing options for the [autoPrefixer](https://www.npmjs.com/package/autoprefixer#options). The autoPrefixer instance generation is memoized, so using the same `autoPrefixerOpts` prop across multiple `Style` components should be performant.
+This prop can be set to any plain object containing options for the [autoprefixer](https://www.npmjs.com/package/autoprefixer#options). The autoprefixer instance generation is memoized, so using the same `autoprefixerOptions` prop across multiple `Style` components should be performant.
 
 ### Global Options
 
@@ -171,7 +171,7 @@ Style.setGlobalOptions({
   doNotPrefix: true,
   hasSourceMap: true,
   isMinified: true,
-  autoPrefixerOpts: { remove: true }
+  autoprefixerOptions: { remove: true }
 });
 ```
 

--- a/src/Style.js
+++ b/src/Style.js
@@ -1,6 +1,5 @@
 // external dependencies
 import isNull from 'lodash/isNull';
-import moize from 'moize';
 import React, {
   Component,
   PropTypes
@@ -171,7 +170,7 @@ export const createSetCorrectTag = (instance) => {
         hasSourceMap: hasSourceMapGlobal
       } = globalProperties;
 
-      const hasSourceMapFinal = instance.getCoalescedPropsValue(hasSourceMap, hasSourceMapGlobal);
+      const hasSourceMapFinal = getCoalescedPropsValue(hasSourceMap, hasSourceMapGlobal);
 
       if (hasSourceMapFinal) {
         instance.setLinkTag();
@@ -194,7 +193,7 @@ export const createSetLinkTag = (instance) => {
       children,
       doNotPrefix,
       isMinified,
-      autoPrefixerOpts
+      autoprefixerOptions
     } = instance.props;
 
     throwErrorIfIsNotText(children);
@@ -208,14 +207,13 @@ export const createSetLinkTag = (instance) => {
     const {
       doNotPrefix: doNotPrefixGlobal,
       isMinified: isMinifiedGlobal,
-      autoPrefixerOpts: autoPrefixerOptsGlobal
+      autoprefixerOptions: autoprefixerOptionsGlobal
     } = globalProperties;
 
-    const doNotPrefixFinal = instance.getCoalescedPropsValue(doNotPrefix, doNotPrefixGlobal);
-    const isMinifiedFinal = instance.getCoalescedPropsValue(isMinified, isMinifiedGlobal);
-    // not using memoized version for autoPrefixerOpts as memoizing object will be more expensive than undefined check
-    const autoPrefixerOptsFinal = getCoalescedPropsValue(autoPrefixerOpts, autoPrefixerOptsGlobal);
-    const transformedCss = getTransformedCss(children, doNotPrefixFinal, isMinifiedFinal, autoPrefixerOptsFinal);
+    const doNotPrefixFinal = getCoalescedPropsValue(doNotPrefix, doNotPrefixGlobal);
+    const isMinifiedFinal = getCoalescedPropsValue(isMinified, isMinifiedGlobal);
+    const autoprefixerOptionsFinal = getCoalescedPropsValue(autoprefixerOptions, autoprefixerOptionsGlobal);
+    const transformedCss = getTransformedCss(children, doNotPrefixFinal, isMinifiedFinal, autoprefixerOptionsFinal);
 
     const link = instance.link;
     const blob = new window.Blob([transformedCss], {
@@ -240,27 +238,26 @@ export const createSetStyleTag = (instance) => {
       children,
       doNotPrefix,
       isMinified,
-      autoPrefixerOpts
+      autoprefixerOptions
     } = instance.props;
 
     const {
       doNotPrefix: doNotPrefixGlobal,
       isMinified: isMinifiedGlobal,
-      autoPrefixerOpts: autoPrefixerOptsGlobal
+      autoprefixerOptions: autoprefixerOptionsGlobal
     } = globalProperties;
 
     throwErrorIfIsNotText(children);
 
     instance.removeTagFromHead('link');
 
-    const doNotPrefixFinal = instance.getCoalescedPropsValue(doNotPrefix, doNotPrefixGlobal);
-    const isMinifiedFinal = instance.getCoalescedPropsValue(isMinified, isMinifiedGlobal);
-    // not using memoized version for autoPrefixerOpts as memoizing object will be more expensive than undefined check
-    const autoPrefixerOptsFinal = instance.getCoalescedPropsValue(autoPrefixerOpts, autoPrefixerOptsGlobal);
+    const doNotPrefixFinal = getCoalescedPropsValue(doNotPrefix, doNotPrefixGlobal);
+    const isMinifiedFinal = getCoalescedPropsValue(isMinified, isMinifiedGlobal);
+    const autoprefixerOptionsFinal = getCoalescedPropsValue(autoprefixerOptions, autoprefixerOptionsGlobal);
 
     const style = instance.style;
 
-    style.textContent = getTransformedCss(children, doNotPrefixFinal, isMinifiedFinal, autoPrefixerOptsFinal);
+    style.textContent = getTransformedCss(children, doNotPrefixFinal, isMinifiedFinal, autoprefixerOptionsFinal);
 
     document.head.appendChild(style);
   };
@@ -276,7 +273,7 @@ export const createSetStyleTag = (instance) => {
  * @param {boolean} [options.doNotPrefix]
  * @param {boolean} [options.hasSourceMap]
  * @param {boolean} [options.isMinified]
- * @param {object} [options.autoPrefixerOpts]
+ * @param {object} [options.autoprefixerOptions]
  * @returns {Object} globalProperties
  */
 export const setGlobalOptions = (options) => {
@@ -296,9 +293,9 @@ class Style extends Component {
     hasSourceMap: PropTypes.bool,
     id: PropTypes.string,
     isMinified: PropTypes.bool,
-    autoPrefixerOpts: PropTypes.shape({
+    autoprefixerOptions: PropTypes.shape({
       // shape defined by autoprefixer options documentation at https://www.npmjs.com/package/autoprefixer
-      browsers: PropTypes.array,
+      browsers: PropTypes.arrayOf(PropTypes.string),
       env: PropTypes.string,
       cascade: PropTypes.bool,
       add: PropTypes.bool,
@@ -330,7 +327,6 @@ class Style extends Component {
   static setGlobalOptions = setGlobalOptions;
 
   // instance methods
-  getCoalescedPropsValue = moize(getCoalescedPropsValue);
   removeTagFromHead = createRemoveTagFromHead(this);
   setCorrectTag = createSetCorrectTag(this);
   setLinkRef = createAssignRefToInstance(this, 'link');
@@ -349,7 +345,7 @@ class Style extends Component {
       hasSourceMap,
       id: idIgnored,
       isMinified: isMinifiedIgnored,
-      autoPrefixerOpts: autoPrefixerOptsIgnored,
+      autoprefixerOptions: autoprefixerOptionsIgnored,
       ...otherProps
     } = this.props;
 
@@ -357,7 +353,7 @@ class Style extends Component {
       hasSourceMap: hasSourceMapGlobal
     } = globalProperties;
 
-    const hasSourceMapFinal = this.getCoalescedPropsValue(hasSourceMap, hasSourceMapGlobal);
+    const hasSourceMapFinal = getCoalescedPropsValue(hasSourceMap, hasSourceMapGlobal);
 
     if (hasSourceMapFinal && hasBlobSupport) {
       return (

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,9 @@
-// external dependencies
-import autoprefixer from 'autoprefixer';
-import postcss from 'postcss';
+/**
+ * @constant {Object} DEFAULT_AUTOPREFIXER_OPTS
+ */
+export const DEFAULT_AUTOPREFIXER_OPTS = {
+  remove: false
+};
 
 /**
  * @constant {Object} REACT_STYLE_TAG_GLOBAL_PROPERTIES
@@ -8,8 +11,10 @@ import postcss from 'postcss';
 export const DEFAULT_REACT_STYLE_TAG_GLOBAL_PROPERTIES = {
   doNotPrefix: false,
   hasSourceMap: false,
-  isMinified: false
+  isMinified: false,
+  autoPrefixerOpts: DEFAULT_AUTOPREFIXER_OPTS
 };
+
 
 /**
  * @constant {string} NO_BLOB_SUPPORT_ERROR
@@ -25,12 +30,3 @@ support it. Please import the included polyfill at 'react-style-tag/blob-polyfil
  * @default
  */
 export const ONLY_TEXT_ERROR = 'The only type of child that can be used in the <Style/> tag is text.';
-
-/**
- * @constants {Object} PREFIXER
- */
-export const PREFIXER = postcss([
-  autoprefixer({
-    remove: false
-  })
-]);

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,7 +1,7 @@
 /**
- * @constant {Object} DEFAULT_AUTOPREFIXER_OPTS
+ * @constant {Object} DEFAULT_AUTOPREFIXER_OPTIONS
  */
-export const DEFAULT_AUTOPREFIXER_OPTS = {
+export const DEFAULT_AUTOPREFIXER_OPTIONS = {
   remove: false
 };
 
@@ -12,7 +12,7 @@ export const DEFAULT_REACT_STYLE_TAG_GLOBAL_PROPERTIES = {
   doNotPrefix: false,
   hasSourceMap: false,
   isMinified: false,
-  autoPrefixerOpts: DEFAULT_AUTOPREFIXER_OPTS
+  autoprefixerOptions: DEFAULT_AUTOPREFIXER_OPTIONS
 };
 
 

--- a/src/transform.js
+++ b/src/transform.js
@@ -1,16 +1,15 @@
 // external dependencies
 import compose from 'lodash/fp/compose';
-import isEqual from 'lodash/isEqual';
 import isUndefined from 'lodash/isUndefined';
 import moize from 'moize';
 import autoprefixer from 'autoprefixer';
 import postcss from 'postcss';
 
 // constants
-import {DEFAULT_AUTOPREFIXER_OPTS} from './constants';
+import {DEFAULT_AUTOPREFIXER_OPTIONS} from './constants';
 
 /**
- * @function getAutoPrefixer
+ * @function getAutoprefixer
  *
  * @description
  * Function that returns an autoprefixer instance configured with the provided options.
@@ -19,11 +18,11 @@ import {DEFAULT_AUTOPREFIXER_OPTS} from './constants';
  * @param {object} options
  * @returns {object}
  */
-export const getAutoPrefixer = moize((autoPrefixerOpts) => {
+export const getAutoprefixer = moize((autoprefixerOptions) => {
   return postcss([
-    autoprefixer(autoPrefixerOpts)
+    autoprefixer(autoprefixerOptions)
   ]);
-}, {equals: isEqual});
+});
 
 /**
  * @function getCoalescedPropsValue
@@ -70,11 +69,11 @@ export const minify = (cssText) => {
  * return the css after running through autoprefixer
  *
  * @param {string} cssText
- * @param {object} autoPrefixerOpts
+ * @param {object} autoprefixerOptions
  * @returns {string}
  */
-export const prefixCss = (cssText, autoPrefixerOpts) => {
-  return getAutoPrefixer(autoPrefixerOpts).process(cssText).css;
+export const prefixCss = (cssText, autoprefixerOptions) => {
+  return getAutoprefixer(autoprefixerOptions).process(cssText).css;
 };
 
 /**
@@ -98,18 +97,18 @@ export const prefixAndMinifyCss = compose(minify, prefixCss);
  * @param {string} cssText
  * @param {boolean} doNotPrefix=false
  * @param {boolean} isMinified=false
- * @param {object} autoPrefixerOpts=
+ * @param {object} autoprefixerOptions=DEFAULT_AUTOPREFIXER_OPTIONS
  * @returns {string}
  */
 export const getTransformedCss = (
   cssText,
   doNotPrefix = false,
   isMinified = false,
-  autoPrefixerOpts = DEFAULT_AUTOPREFIXER_OPTS
+  autoprefixerOptions = DEFAULT_AUTOPREFIXER_OPTIONS
 ) => {
   if (!isMinified) {
-    return doNotPrefix ? cssText : prefixCss(cssText, autoPrefixerOpts);
+    return doNotPrefix ? cssText : prefixCss(cssText, autoprefixerOptions);
   }
 
-  return doNotPrefix ? minify(cssText) : prefixAndMinifyCss(cssText, autoPrefixerOpts);
+  return doNotPrefix ? minify(cssText) : prefixAndMinifyCss(cssText, autoprefixerOptions);
 };

--- a/src/transform.js
+++ b/src/transform.js
@@ -13,7 +13,7 @@ import {DEFAULT_AUTOPREFIXER_OPTIONS} from './constants';
  *
  * @description
  * Function that returns an autoprefixer instance configured with the provided options.
- * Memoized for better performance (uses lodash isEqual for equality check)
+ * Memoized for better performance
  *
  * @param {object} options
  * @returns {object}

--- a/test/Style.js
+++ b/test/Style.js
@@ -213,7 +213,6 @@ test.serial('if createRemoveTagFromHead will create a method that that gets the 
 
 test('if createSetCorrectTag will call the right tag function based on hasSourceMap being false', (t) => {
   const instance = {
-    getCoalescedPropsValue: sinon.stub().returns(false),
     id: 'foo',
     props: {
       hasSourceMap: undefined
@@ -221,6 +220,7 @@ test('if createSetCorrectTag will call the right tag function based on hasSource
     setLinkTag: sinon.spy(),
     setStyleTag: sinon.spy()
   };
+  const getCoalescedPropsValue = sinon.spy(transform, 'getCoalescedPropsValue');
 
   const setCorrectTag = component.createSetCorrectTag(instance);
 
@@ -228,23 +228,25 @@ test('if createSetCorrectTag will call the right tag function based on hasSource
 
   setCorrectTag();
 
-  t.true(instance.getCoalescedPropsValue.calledOnce);
+  t.true(getCoalescedPropsValue.calledOnce);
 
   t.true(instance.setLinkTag.notCalled);
 
   t.true(instance.setStyleTag.calledOnce);
+
+  transform.getCoalescedPropsValue.restore();
 });
 
 test('if createSetCorrectTag will call the right tag function based on hasSourceMap being true', (t) => {
   const instance = {
-    getCoalescedPropsValue: sinon.stub().returns(true),
     id: 'foo',
     props: {
-      hasSourceMap: undefined
+      hasSourceMap: true
     },
     setLinkTag: sinon.spy(),
     setStyleTag: sinon.spy()
   };
+  const getCoalescedPropsValue = sinon.spy(transform, 'getCoalescedPropsValue');
 
   const setCorrectTag = component.createSetCorrectTag(instance);
 
@@ -252,16 +254,17 @@ test('if createSetCorrectTag will call the right tag function based on hasSource
 
   setCorrectTag();
 
-  t.true(instance.getCoalescedPropsValue.calledOnce);
+  t.true(getCoalescedPropsValue.calledOnce);
 
   t.true(instance.setLinkTag.calledOnce);
 
   t.true(instance.setStyleTag.notCalled);
+
+  transform.getCoalescedPropsValue.restore();
 });
 
 test('if createSetCorrectTag will call nothing if the instance id is null', (t) => {
   const instance = {
-    getCoalescedPropsValue: sinon.stub().returns(true),
     id: null,
     props: {
       hasSourceMap: undefined
@@ -269,6 +272,7 @@ test('if createSetCorrectTag will call nothing if the instance id is null', (t) 
     setLinkTag: sinon.spy(),
     setStyleTag: sinon.spy()
   };
+  const getCoalescedPropsValue = sinon.spy(transform, 'getCoalescedPropsValue');
 
   const setCorrectTag = component.createSetCorrectTag(instance);
 
@@ -276,16 +280,17 @@ test('if createSetCorrectTag will call nothing if the instance id is null', (t) 
 
   setCorrectTag();
 
-  t.true(instance.getCoalescedPropsValue.notCalled);
+  t.true(getCoalescedPropsValue.notCalled);
 
   t.true(instance.setLinkTag.notCalled);
 
   t.true(instance.setStyleTag.notCalled);
+
+  transform.getCoalescedPropsValue.restore();
 });
 
 test.serial('if createSetLinkTag will create a link tag with the correct values', (t) => {
   const instance = {
-    getCoalescedPropsValue: sinon.stub().returns(false),
     link: {
       href: null
     },
@@ -293,7 +298,7 @@ test.serial('if createSetLinkTag will create a link tag with the correct values'
       children: 'foo',
       doNotPrefix: false,
       isMinified: false,
-      autoPrefixerOpts: constants.DEFAULT_AUTOPREFIXER_OPTS
+      autoprefixerOptions: constants.DEFAULT_AUTOPREFIXER_OPTIONS
     },
     removeTagFromHead: sinon.spy()
   };
@@ -341,7 +346,6 @@ test.serial('if createSetLinkTag will create a link tag with the correct values'
 
 test.serial('if createSetStyleTag will create a link tag with the correct values', (t) => {
   const instance = {
-    getCoalescedPropsValue: sinon.stub().returns(false),
     style: {
       textContent: null
     },
@@ -349,7 +353,7 @@ test.serial('if createSetStyleTag will create a link tag with the correct values
       children: 'foo',
       doNotPrefix: false,
       isMinified: false,
-      autoPrefixerOpts: constants.DEFAULT_AUTOPREFIXER_OPTS
+      autoprefixerOptions: constants.DEFAULT_AUTOPREFIXER_OPTIONS
     },
     removeTagFromHead: sinon.spy()
   };
@@ -432,7 +436,7 @@ test('if setGlobalOptions will set the global properties based on the options pa
   const overrides = {
     doNotPrefix: true,
     isMinified: true,
-    autoPrefixerOpts: {
+    autoprefixerOptions: {
       flexbox: true,
       grid: true
     }
@@ -444,7 +448,7 @@ test('if setGlobalOptions will set the global properties based on the options pa
     ...constants.DEFAULT_REACT_STYLE_TAG_GLOBAL_PROPERTIES,
     doNotPrefix: true,
     isMinified: true,
-    autoPrefixerOpts: {
+    autoprefixerOptions: {
       flexbox: true,
       grid: true
     }

--- a/test/Style.js
+++ b/test/Style.js
@@ -292,7 +292,8 @@ test.serial('if createSetLinkTag will create a link tag with the correct values'
     props: {
       children: 'foo',
       doNotPrefix: false,
-      isMinified: false
+      isMinified: false,
+      autoPrefixerOpts: constants.DEFAULT_AUTOPREFIXER_OPTS
     },
     removeTagFromHead: sinon.spy()
   };
@@ -347,7 +348,8 @@ test.serial('if createSetStyleTag will create a link tag with the correct values
     props: {
       children: 'foo',
       doNotPrefix: false,
-      isMinified: false
+      isMinified: false,
+      autoPrefixerOpts: constants.DEFAULT_AUTOPREFIXER_OPTS
     },
     removeTagFromHead: sinon.spy()
   };
@@ -429,7 +431,11 @@ test('if setGlobalOptions have the correct defaults', (t) => {
 test('if setGlobalOptions will set the global properties based on the options passed', (t) => {
   const overrides = {
     doNotPrefix: true,
-    isMinified: true
+    isMinified: true,
+    autoPrefixerOpts: {
+      flexbox: true,
+      grid: true
+    }
   };
 
   const result = component.setGlobalOptions(overrides);
@@ -437,18 +443,12 @@ test('if setGlobalOptions will set the global properties based on the options pa
   t.deepEqual(result, {
     ...constants.DEFAULT_REACT_STYLE_TAG_GLOBAL_PROPERTIES,
     doNotPrefix: true,
-    isMinified: true
+    isMinified: true,
+    autoPrefixerOpts: {
+      flexbox: true,
+      grid: true
+    }
   });
-});
-
-test('if setGlobalOptions will throw a TypeError when an override is not a boolean', (t) => {
-  const overrides = {
-    doNotPrefix: 'foo'
-  };
-
-  t.throws(() => {
-    component.setGlobalOptions(overrides);
-  }, TypeError);
 });
 
 test('if Style will render correctly when using a style tag', (t) => {

--- a/test/transform.js
+++ b/test/transform.js
@@ -44,7 +44,7 @@ test.serial('if getTransformedCss returns the prefixed cssText if doNotPrefix is
   const result = transform.getTransformedCss(cssText, doNotPrefix, isMinified);
 
   t.not(result, cssText);
-  t.is(result, transform.prefixCss(cssText, constants.DEFAULT_AUTOPREFIXER_OPTS));
+  t.is(result, transform.prefixCss(cssText, constants.DEFAULT_AUTOPREFIXER_OPTIONS));
 });
 
 test.serial('if getTransformedCss returns the minified cssText if doNotPrefix is true and isMinified is true', (t) => {
@@ -66,18 +66,18 @@ test.serial('if getTransformedCss returns the prefixed and minified cssText if d
   const result = transform.getTransformedCss(cssText, doNotPrefix, isMinified);
 
   t.not(result, cssText);
-  t.is(result, transform.prefixAndMinifyCss(cssText, constants.DEFAULT_AUTOPREFIXER_OPTS));
+  t.is(result, transform.prefixAndMinifyCss(cssText, constants.DEFAULT_AUTOPREFIXER_OPTIONS));
 });
 
-test.serial('if getTransformedCss uses autoPrefixerOpts for prefixing', (t) => {
+test.serial('if getTransformedCss uses autoprefixerOptions for prefixing', (t) => {
   const cssText = '.foo { display: flex; }';
   const doNotPrefix = false;
   const isMinified = false;
-  const autoPrefixerOpts = {grid: true, flexbox: false};
-  const result = transform.getTransformedCss(cssText, doNotPrefix, isMinified, autoPrefixerOpts);
+  const autoprefixerOptions = {grid: true, flexbox: false};
+  const result = transform.getTransformedCss(cssText, doNotPrefix, isMinified, autoprefixerOptions);
 
-  t.not(result, transform.prefixCss(cssText, constants.DEFAULT_AUTOPREFIXER_OPTS));
-  t.is(result, transform.prefixCss(cssText, autoPrefixerOpts));
+  t.not(result, transform.prefixCss(cssText, constants.DEFAULT_AUTOPREFIXER_OPTIONS));
+  t.is(result, transform.prefixCss(cssText, autoprefixerOptions));
 });
 
 test('if minify will minify the css text', (t) => {
@@ -98,20 +98,19 @@ test('if minify will minify the css text', (t) => {
   t.is(result, expectedResult);
 });
 
-test.serial('if prefixCss calls getAutoPrefixer to generate an autoPrefixer and uses it', (t) => {
-  // since getAutoPrefixer is memoized, lets grab the default autoprefixer
-  const autoPrefixerDefault = transform.getAutoPrefixer(constants.DEFAULT_AUTOPREFIXER_OPTS);
+test.serial('if prefixCss calls getAutoprefixer to generate an autoprefixer and uses it', (t) => {
+  // since getAutoprefixer is memoized, lets grab the default autoprefixer
+  const autoprefixerDefault = transform.getAutoprefixer(constants.DEFAULT_AUTOPREFIXER_OPTIONS);
 
   const cssText = '.foo { display: flex; }';
 
-  const stub = sinon.stub(autoPrefixerDefault, 'process').returns({
+  const stub = sinon.stub(autoprefixerDefault, 'process').returns({
     css: 'foo'
   });
 
-  transform.prefixCss(cssText, constants.DEFAULT_AUTOPREFIXER_OPTS);
+  transform.prefixCss(cssText, constants.DEFAULT_AUTOPREFIXER_OPTIONS);
 
   t.true(stub.calledOnce);
   t.true(stub.calledWithExactly(cssText));
-
   stub.restore();
 });


### PR DESCRIPTION
This PR adds support for `autoPrefixerOpts` prop, allowing the user to pass in options for the autoPrefixer on a per-component or global basis. The autoPrefixer instance generation is wrapped with moize for efficiency (based on the assumption that most end users will use a single configuration across an entire project)